### PR TITLE
Add vertical scroll to position of context menu

### DIFF
--- a/scripts/flex.js
+++ b/scripts/flex.js
@@ -403,7 +403,7 @@
     return {
       x: posX,
       y: posY
-    }
+    };
   }
 
 
@@ -418,7 +418,7 @@
     const menuWidth = menu.offsetWidth + MENU_OFFSET;
     const menuHeight = menu.offsetHeight + MENU_OFFSET;
     const windowWidth = window.innerWidth;
-    const windowHeight = window.innerHeight;
+    const windowHeight = window.innerHeight + window.scrollY;
 
     if((windowWidth - menuPosition.x) < menuWidth) {
       menu.style.left = windowWidth - menuWidth + "px";


### PR DESCRIPTION
Adds vertical scroll position to the calculation for the position of the context menu. If the viewport is scrolled down (narrow window), the amount scrolled is added to the height of the window when calculating if the menu would be off screen.

**Before**
![gif](https://i.imgur.com/1AP32AX.gif)

**After**
![screenshot](https://user-images.githubusercontent.com/6354860/95180903-6b70f680-0777-11eb-9d39-5bb82f82ba18.png)
